### PR TITLE
Add slh2 to brands

### DIFF
--- a/CSV/brands.csv
+++ b/CSV/brands.csv
@@ -185,6 +185,7 @@ senv,Video contents Sony Entertainment Network provides by using MP4 file format
 sims,Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.,DASH
 sisx,Single Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 slh1,Dynamic metadata for Single Layer SDR-compatible HDR video streams,SL-HDR
+slh2,Dynamic metadata for Single Layer PQ-based HDR video streams,SL-HDR 
 ssss,Subsegment Index Segment used to index MPEG-2 TS based Media Segments.,DASH
 uvvu,"UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",DECE
 XAVC,XAVC File Format,Sony


### PR DESCRIPTION
'slh2' is defined in Annex H of ETSI TS 103 433-1, which is Part 1 of the SL-HDR specifications.
It indicates the presence of SL-HDR2 metadata, for which the processing is specified in Part 2 (TS 103 433-2).